### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,20 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>aerius-nexus-public</id>
+      <name>AERIUS Nexus Repository</name>
+      <url>https://nexus.aerius.nl/repository/maven-public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
-    <tomcat.version>9.0.65</tomcat.version>
+    <tomcat.version>9.0.69</tomcat.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <aerius-tools.version>1.2.0-SNAPSHOT</aerius-tools.version>
+    <aerius-tools.version>1.2.0</aerius-tools.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This should clear up at least once CVE warning about tomcat-embed-core-9.0.65: CVE-2022-42252 Had to reference the aerius nexus repository for pluginRepositories as well to use aerius-tools 1.2.0.